### PR TITLE
fix frontend proxy controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/FrontendProxyController.java
@@ -19,7 +19,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte[]> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();


### PR DESCRIPTION
In this PR, we fix a bug with the frontend proxy controller causing GET requests for static assets in development mode to funciton incorrectly. Previously, the proxy controller would cast the ResponseEntity from the frontend running on localhost:3000 to a String. This means that if you tried to fetch something like an image, the response from localhost:8080 would be null:
![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-3/assets/86684522/e17064b6-a4e4-48de-bb44-0e5a7dc23f05)

Now, the proxy controller takes in a response of type byte array and returns a response of type wildcard, according to the documentation here: 
https://cloud.spring.io/spring-cloud-gateway/multi/multi__building_a_simple_gateway_using_spring_mvc.html
And the response shows up correctly:
![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-3/assets/86684522/2a038f1f-5fc9-4759-a6bc-9c1e47c2a800)
